### PR TITLE
feat(subscribe): 按行情源订阅 —— 协议增 source，subscribe 带 source 参数

### DIFF
--- a/example/subscription/python/live_subscribe_example.py
+++ b/example/subscription/python/live_subscribe_example.py
@@ -1,5 +1,11 @@
 """
-demo.py — Python 客户端 demo（对齐 C++ client_main.cpp）
+live_subscribe_example.py — libfinance 流式订阅 demo（按行情源订阅）
+
+用法:
+    python live_subscribe_example.py [host] [port] [source]
+    - 给定 source：只订该源的 600519.SSE
+    - 不给 source：一条连接同时混订 webquote 与 sim 的 600519.SSE，
+      on_depth_market_data 里靠 quote.source 区分来源（webquote 为真实行情）。
 """
 
 import sys
@@ -43,7 +49,7 @@ class MyQuoteSpi(QuoteSpi):
     def on_rsp_subscribe(self, rsp: SubRsp, request_id: int):
         if rsp.error_id == 0:
             max_str = "unlimited" if rsp.max_subs < 0 else str(rsp.max_subs)
-            print(f"[SPI] subscribed {rsp.exchange_id}.{rsp.instrument_id}"
+            print(f"[SPI] subscribed {rsp.source}:{rsp.exchange_id}.{rsp.instrument_id}"
                   f"  [{rsp.current_subs}/{max_str}]")
         elif rsp.error_id == 3:
             print(f"[SPI] subscribe QUOTA EXCEEDED: {rsp.error_msg}"
@@ -52,12 +58,13 @@ class MyQuoteSpi(QuoteSpi):
             print(f"[SPI] subscribe fail: {rsp.error_msg}")
 
     def on_rsp_unsubscribe(self, rsp: SubRsp, request_id: int):
-        print(f"[SPI] unsubscribed {rsp.exchange_id}.{rsp.instrument_id}")
+        print(f"[SPI] unsubscribed {rsp.source}:{rsp.exchange_id}.{rsp.instrument_id}")
 
     def on_depth_market_data(self, q: Quote):
         self.count += 1
         print(
             f"[QUOTE #{self.count:5d}] "
+            f"src={q.source:<10s} "
             f"{q.exchange_id}.{q.instrument_id}"
             f"  last={q.last_price:10.3f}"
             f"  bid1={q.bid_price[0]:10.3f}"
@@ -72,6 +79,7 @@ class MyQuoteSpi(QuoteSpi):
 def main():
     host = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
     port = int(sys.argv[2]) if len(sys.argv) > 2 else 9001
+    source = sys.argv[3] if len(sys.argv) > 3 else ""
 
     spi = MyQuoteSpi()
     api = QuoteApi()
@@ -85,14 +93,19 @@ def main():
     #api.login("trader1", "pass1234")
     #time.sleep(0.3)
 
-    api.subscribe(["rb2501", "hc2501"], "SHFE")
-    api.subscribe(["i2501", "j2501"], "DCE")
-    api.subscribe(["600000", "600001"], "SSE")
+    if source:
+        print(f"[Client] subscribing source={source} 600519.SSE")
+        api.subscribe(["600519"], "SSE", source=source)
+    else:
+        # 一条连接混订两源同一合约，回调里靠 quote.source 区分
+        print("[Client] multiplexing webquote + sim on 600519.SSE")
+        api.subscribe(["600519"], "SSE", source="webquote")
+        api.subscribe(["600519"], "SSE", source="sim")
 
     time.sleep(5)
-    if not g_stop.is_set():
-        print("\n[Client] unsubscribing rb2501...")
-        api.unsubscribe(["rb2501"], "SHFE")
+    if not g_stop.is_set() and source:
+        print("\n[Client] unsubscribing 600519...")
+        api.unsubscribe(["600519"], "SSE", source=source)
 
     g_stop.wait()  # blocks until set by signal or disconnect
 

--- a/libfinance/subscribe/md_protocol.py
+++ b/libfinance/subscribe/md_protocol.py
@@ -10,8 +10,9 @@ from enum import IntEnum
 
 # ── 常量 ──────────────────────────────────────────────────────────
 MAGIC = 0x4B463235  # "KF25"
-VERSION = 1
+VERSION = 2          # v2: SubReq/SubRsp/Quote 增 source[16]
 HEADER_SIZE = 16
+SOURCE_LEN = 16
 
 # ── 消息类型 ──────────────────────────────────────────────────────
 class MsgType(IntEnum):
@@ -78,24 +79,26 @@ def unpack_login_rsp(data: bytes) -> LoginRsp:
     )
 
 
-# ── SubReq: char[8] + char[32] = 40 bytes ────────────────────────
-SUB_REQ_FMT = "<8s32s"
+# ── SubReq: char[16] + char[8] + char[32] = 56 bytes ─────────────
+SUB_REQ_FMT = "<16s8s32s"
 SUB_REQ_SIZE = struct.calcsize(SUB_REQ_FMT)
 
-def pack_sub_req(exchange_id: str, instrument_id: str) -> bytes:
+def pack_sub_req(exchange_id: str, instrument_id: str, source: str = "") -> bytes:
     return struct.pack(
         SUB_REQ_FMT,
+        source.encode().ljust(16, b"\x00")[:16],
         exchange_id.encode().ljust(8, b"\x00")[:8],
         instrument_id.encode().ljust(32, b"\x00")[:32],
     )
 
 
-# ── SubRsp: char[8] + char[32] + int32 + char[64] + int32 + int32 = 116 bytes
-SUB_RSP_FMT = "<8s32si64sii"
+# ── SubRsp: char[16] + char[8] + char[32] + int32 + char[64] + int32 + int32 = 132 bytes
+SUB_RSP_FMT = "<16s8s32si64sii"
 SUB_RSP_SIZE = struct.calcsize(SUB_RSP_FMT)
 
 @dataclass
 class SubRsp:
+    source: str
     exchange_id: str
     instrument_id: str
     error_id: int
@@ -104,9 +107,10 @@ class SubRsp:
     max_subs: int        # 最大订阅数，-1 无限制
 
 def unpack_sub_rsp(data: bytes) -> SubRsp:
-    exch, inst, error_id, error_msg_raw, current_subs, max_subs = struct.unpack(
+    src, exch, inst, error_id, error_msg_raw, current_subs, max_subs = struct.unpack(
         SUB_RSP_FMT, data[:SUB_RSP_SIZE])
     return SubRsp(
+        src.split(b"\x00", 1)[0].decode(),
         exch.split(b"\x00", 1)[0].decode(),
         inst.split(b"\x00", 1)[0].decode(),
         error_id,
@@ -157,6 +161,7 @@ WIRE_QUOTE_FMT = (
     "10q"      # ask_volume[10]
     "8s"       # trading_phase_code
     "q"        # data_time
+    "16s"      # source（追加在末尾）
 )
 WIRE_QUOTE_SIZE = struct.calcsize(WIRE_QUOTE_FMT)
 
@@ -188,6 +193,7 @@ class Quote:
     ask_volume: list      # [10]
     trading_phase_code: str
     data_time: int
+    source: str
 
 
 def unpack_quote(data: bytes) -> Quote:
@@ -217,6 +223,7 @@ def unpack_quote(data: bytes) -> Quote:
         bid_price=_fa(10), ask_price=_fa(10),
         bid_volume=_ia(10), ask_volume=_ia(10),
         trading_phase_code=_s(), data_time=_i(),
+        source=_s(),
     )
 
 

--- a/libfinance/subscribe/quote_api.py
+++ b/libfinance/subscribe/quote_api.py
@@ -6,7 +6,9 @@ quote_api.py — Python 客户端 SDK（XTP 风格，对齐 C++ client/quote_api
     api.register_spi(my_spi)
     api.connect("127.0.0.1", 9001)
     api.login("trader1", "pass1234")
-    api.subscribe(["rb2501", "hc2501"], "SHFE")
+    # 按行情源订阅（一条连接可混订多源，回调里 quote.source 区分）
+    api.subscribe(["600519"], "SSE", source="webquote")
+    api.subscribe(["600519"], "SSE", source="sim")
 """
 
 import socket
@@ -87,21 +89,23 @@ class QuoteApi:
         return seq
 
     # ── 订阅 ──────────────────────────────────────────────────────
-    def subscribe(self, instruments: List[str], exchange_id: str) -> int:
+    # source：行情源（sim / cxxquote / webquote / ...）。空 = 网关默认源。
+    # 一条连接可对不同 source 分别 subscribe，行情回调里靠 quote.source 区分。
+    def subscribe(self, instruments: List[str], exchange_id: str, source: str = "") -> int:
         last = 0
         for inst in instruments:
             seq = self._next_seq()
-            body = pack_sub_req(exchange_id, inst)
+            body = pack_sub_req(exchange_id, inst, source)
             self._enqueue(make_frame(MsgType.REQ_SUBSCRIBE, seq, body))
             last = seq
         return last
 
     # ── 退订 ──────────────────────────────────────────────────────
-    def unsubscribe(self, instruments: List[str], exchange_id: str) -> int:
+    def unsubscribe(self, instruments: List[str], exchange_id: str, source: str = "") -> int:
         last = 0
         for inst in instruments:
             seq = self._next_seq()
-            body = pack_sub_req(exchange_id, inst)
+            body = pack_sub_req(exchange_id, inst, source)
             self._enqueue(make_frame(MsgType.REQ_UNSUBSCRIBE, seq, body))
             last = seq
         return last


### PR DESCRIPTION
## 目标
libfinance 流式订阅（`libfinance.subscribe`）支持按行情源订阅，回调里靠 `quote.source` 区分来源。
对齐 mdgateway PR #12 的协议 v2。

## 改动
- `subscribe/md_protocol.py`：`SubReq`/`SubRsp`/`Quote` 各增 `source[16]`（`Quote.source` 追加在末尾
  → 其余字段偏移不变）。尺寸 SubReq=56 / SubRsp=132 / Quote=525，`VERSION=2`（与 C++ `struct` 逐字节对齐，
  `struct.calcsize` 校验通过）。
- `subscribe/quote_api.py`：`subscribe/unsubscribe(instruments, exchange, source="")`。一条连接可对不同
  source 分别订阅，互不串扰。
- `example/subscription/python/live_subscribe_example.py`：演示一条连接混订 `webquote` 与 `sim` 的
  `600519.SSE`，打印 `quote.source`。

## 验证
- 协议尺寸自检通过（SubReq 56 / SubRsp 132 / Quote 525 / VERSION 2）。
- 真实端到端（连真实 webquote 行情）在 mdgateway compose 栈起来后验证（后续）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)