### PR TITLE
feat(subscribe): QuoteApi.subscribe_all(source) 全市场订阅

### DIFF
--- a/example/subscription/python/fullmarket_health_check.py
+++ b/example/subscription/python/fullmarket_health_check.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+fullmarket_health_check.py —— 实时行情源「全市场」体检
+
+对某个行情源做【全市场订阅】(subscribe_all)，统计覆盖（出数标的数）、吞吐、
+延迟/新鲜度，判断该源是否健康。
+
+走 subscribe_all：网关让源端走全量推送（如 webquote→yunhq 全沪深 ~5289 只），
+**客户端不枚举任何代码** —— 因此覆盖即真实全市场、不含空号（旧版按代码段位生成
+11000 含大量空号的问题不复存在）。
+
+用法:
+    python fullmarket_health_check.py --source webquote \\
+        --user admin --password 'AdminPass123!' --duration 20
+
+退出码: 0=健康, 1=不健康(0行情 / 出数标的<--min-instruments / p95滞后超阈值), 2=连接或登录失败
+"""
+import argparse
+import signal
+import statistics
+import sys
+import threading
+import time
+
+from libfinance.subscribe.quote_api import QuoteApi, QuoteSpi
+
+
+class HealthSpi(QuoteSpi):
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.logged_in = threading.Event()
+        self.login_ok = False
+        self.sub_ok = False
+        self.sub_err = ""
+        self.first = {}       # "exch.inst" -> 首条到达 wall 时间
+        self.first_dt = {}    # "exch.inst" -> 首条 data_time（算新鲜度）
+        self.total = 0
+
+    def on_rsp_login(self, rsp, _):
+        self.login_ok = (rsp.error_id == 0)
+        mx = "unlimited" if rsp.max_subscriptions < 0 else rsp.max_subscriptions
+        print(f"[health] login {'OK' if self.login_ok else 'FAIL'} "
+              f"level={rsp.user_level} max_subs={mx} "
+              f"{'' if self.login_ok else rsp.error_msg}")
+        self.logged_in.set()
+
+    def on_rsp_subscribe(self, rsp, _):   # subscribe_all 的应答也走这里
+        self.sub_ok = (rsp.error_id == 0)
+        self.sub_err = rsp.error_msg
+
+    def on_depth_market_data(self, q):
+        now = time.time()
+        key = f"{q.exchange_id}.{q.instrument_id}"
+        with self.lock:
+            self.total += 1
+            if key not in self.first:
+                self.first[key] = now
+                self.first_dt[key] = q.data_time
+
+
+def lag_ms(data_time, wall):
+    """kungfu data_time 多为 ns epoch；解析为 now-data_time(ms)，无法判定返回 None。"""
+    if not data_time or data_time <= 0:
+        return None
+    for scale in (1e9, 1e6, 1e3, 1.0):
+        secs = data_time / scale
+        if 9.46e8 < secs < 4.1e9:        # 2000~2100 的合理 epoch 秒
+            return (wall - secs) * 1000.0
+    return None
+
+
+def pct(xs, p):
+    xs = sorted(xs)
+    return xs[min(len(xs) - 1, int(round(p / 100.0 * (len(xs) - 1))))]
+
+
+def main():
+    ap = argparse.ArgumentParser(description="实时行情源全市场体检（subscribe_all）")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=9001)
+    ap.add_argument("--source", required=True, help="行情源名 sim/webquote/...")
+    ap.add_argument("--user", default="", help="登录账户（subscribe_all 需登录的高配额账户）")
+    ap.add_argument("--password", default="")
+    ap.add_argument("--duration", type=int, default=20, help="采集时长(秒)")
+    ap.add_argument("--min-instruments", type=int, default=0,
+                    help="出数标的少于此值判不健康，0=不判")
+    ap.add_argument("--fail-lag-ms", type=float, default=0.0,
+                    help="p95 数据滞后超此(ms)判不健康，0=不判")
+    args = ap.parse_args()
+
+    spi = HealthSpi()
+    api = QuoteApi()
+    api.register_spi(spi)
+    if api.connect(args.host, args.port) != 0:
+        print("[health] connect failed", file=sys.stderr)
+        return 2
+    stop = threading.Event()
+    signal.signal(signal.SIGINT, lambda *_: stop.set())
+
+    if args.user:
+        api.login(args.user, args.password)
+        spi.logged_in.wait(timeout=5)
+        if not spi.login_ok:
+            api.disconnect()
+            return 2
+    else:
+        print("[health][warn] 未登录(guest)：subscribe_all 需登录账户，可能被拒")
+
+    # 全市场订阅：一条 subscribe_all，网关让源端走全量推送（不枚举代码、无空号）
+    print(f"[health] subscribe_all(source={args.source})，采集 {args.duration}s ...")
+    t_sub = time.time()
+    api.subscribe_all(args.source)
+
+    deadline = t_sub + args.duration
+    while time.time() < deadline and not stop.is_set():
+        time.sleep(min(5.0, max(0.0, deadline - time.time())))
+        with spi.lock:
+            covered, tq = len(spi.first), spi.total
+        dt = max(1e-9, time.time() - t_sub)
+        print(f"[health]  +{int(time.time()-t_sub):>3}s  出数标的={covered}  行情={tq}  qps≈{tq/dt:.0f}")
+    api.disconnect()
+
+    # ───────── 汇总 ─────────
+    with spi.lock:
+        covered = len(spi.first)
+        total = spi.total
+        first_lat = sorted((t - t_sub) * 1000.0 for t in spi.first.values())
+        lags = [v for v in (lag_ms(spi.first_dt[k], spi.first[k])
+                            for k in list(spi.first)[:2000]) if v is not None]
+    elapsed = max(1e-9, time.time() - t_sub)
+    if not spi.sub_ok:
+        print(f"[health] subscribe_all 应答: {spi.sub_err or '(未收到)'}", file=sys.stderr)
+
+    print("\n" + "=" * 60)
+    print(f"实时源体检  source={args.source}  {args.host}:{args.port}")
+    print("=" * 60)
+    print(f"覆盖      出数标的={covered}（subscribe_all 全市场，无空号）")
+    print(f"吞吐      总行情={total}  采集={elapsed:.1f}s  qps≈{total/elapsed:.0f}")
+    if first_lat:
+        print(f"首条延迟  中位={statistics.median(first_lat):.0f}ms  "
+              f"p95={pct(first_lat,95):.0f}ms  (订阅→该标的首条)")
+    if lags:
+        print(f"数据滞后  中位={statistics.median(lags):.0f}ms  "
+              f"p95={pct(lags,95):.0f}ms  (now−data_time，抽样{len(lags)})")
+    if covered:
+        avg = total / covered
+        print(f"更新频率  每标的均 {avg:.1f} 条/{elapsed:.0f}s ≈ 每 {elapsed/max(1e-9,avg):.1f}s 一跳")
+
+    bad = []
+    if total == 0:
+        bad.append("采集窗口内 0 行情")
+    if args.min_instruments and covered < args.min_instruments:
+        bad.append(f"出数标的 {covered} < {args.min_instruments}")
+    if args.fail_lag_ms and lags and pct(lags, 95) > args.fail_lag_ms:
+        bad.append(f"p95 滞后 {pct(lags,95):.0f}ms > {args.fail_lag_ms:.0f}ms")
+    print("\n[结论] " + ("✗ 不健康：" + "；".join(bad) if bad
+                        else "✓ 健康：该源全市场持续出数"))
+    print("=" * 60)
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/example/subscription/python/live_subscribe_example.py
+++ b/example/subscription/python/live_subscribe_example.py
@@ -1,79 +1,62 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """
-live_subscribe_example.py — libfinance 流式订阅 demo（按行情源订阅）
+live_subscribe_example.py — libfinance 实时行情订阅示例（按行情源）
 
 用法:
     python live_subscribe_example.py [host] [port] [source]
-    - 给定 source：只订该源的 600519.SSE
-    - 不给 source：一条连接同时混订 webquote 与 sim 的 600519.SSE，
-      on_depth_market_data 里靠 quote.source 区分来源（webquote 为真实行情）。
-"""
+      - 指定 source：订该源的 600519.SSE
+      - 不指定 source：一条连接同时混订 webquote + sim 的 600519.SSE，
+        回调里靠 quote.source 区分来源（同一合约多源并行、互不串扰）。
 
-import sys
+要点：
+    subscribe(instruments, exchange, source=...)  按源订阅
+    on_depth_market_data(quote)                   quote.source 标明来源
+    全市场订阅另见 fullmarket_health_check.py 的 subscribe_all。
+"""
 import signal
-import time
+import sys
 import threading
 
-from libfinance.subscribe.md_protocol import LoginRsp, SubRsp, Quote
 from libfinance.subscribe.quote_api import QuoteApi, QuoteSpi
 
-g_stop = threading.Event()  # 初始 unset，收到信号后 set 表示该停了
+stop = threading.Event()
+for _sig in (signal.SIGINT, signal.SIGTERM):
+    signal.signal(_sig, lambda *_: stop.set())
 
 
-def sig_handler(_sig, _frame):
-    g_stop.set()
-
-signal.signal(signal.SIGINT, sig_handler)
-signal.signal(signal.SIGTERM, sig_handler)
-
-
-class MyQuoteSpi(QuoteSpi):
+class DemoSpi(QuoteSpi):
     def __init__(self):
         self.count = 0
 
     def on_connected(self):
-        print("[SPI] connected")
+        print("[client] connected")
 
-    def on_disconnected(self, reason: int):
-        print(f"[SPI] disconnected reason={reason}")
-        g_stop.set()
+    def on_disconnected(self, reason):
+        print(f"[client] disconnected reason={reason}")
+        stop.set()
 
-    def on_rsp_login(self, rsp: LoginRsp, request_id: int):
-        if rsp.error_id == 0:
-            max_str = "unlimited" if rsp.max_subscriptions < 0 else str(rsp.max_subscriptions)
-            print(f"[SPI] login OK  session_id={rsp.session_id}"
-                  f"  user_level={rsp.user_level}  max_subs={max_str}")
+    def on_rsp_login(self, rsp, _):
+        if rsp.error_id != 0:
+            print(f"[client] login FAIL: {rsp.error_msg}")
+            stop.set()
         else:
-            print(f"[SPI] login FAIL: {rsp.error_msg}")
-            g_stop.set()
+            mx = "unlimited" if rsp.max_subscriptions < 0 else rsp.max_subscriptions
+            print(f"[client] login OK  level={rsp.user_level}  max_subs={mx}")
 
-    def on_rsp_subscribe(self, rsp: SubRsp, request_id: int):
+    def on_rsp_subscribe(self, rsp, _):
         if rsp.error_id == 0:
-            max_str = "unlimited" if rsp.max_subs < 0 else str(rsp.max_subs)
-            print(f"[SPI] subscribed {rsp.source}:{rsp.exchange_id}.{rsp.instrument_id}"
-                  f"  [{rsp.current_subs}/{max_str}]")
+            print(f"[client] subscribed {rsp.source}:{rsp.exchange_id}.{rsp.instrument_id}")
         elif rsp.error_id == 3:
-            print(f"[SPI] subscribe QUOTA EXCEEDED: {rsp.error_msg}"
-                  f"  [{rsp.current_subs}/{rsp.max_subs}]")
+            print(f"[client] QUOTA EXCEEDED: {rsp.error_msg}")
         else:
-            print(f"[SPI] subscribe fail: {rsp.error_msg}")
+            print(f"[client] subscribe fail: {rsp.error_msg}")
 
-    def on_rsp_unsubscribe(self, rsp: SubRsp, request_id: int):
-        print(f"[SPI] unsubscribed {rsp.source}:{rsp.exchange_id}.{rsp.instrument_id}")
-
-    def on_depth_market_data(self, q: Quote):
+    def on_depth_market_data(self, q):
         self.count += 1
-        print(
-            f"[QUOTE #{self.count:5d}] "
-            f"src={q.source:<10s} "
-            f"{q.exchange_id}.{q.instrument_id}"
-            f"  last={q.last_price:10.3f}"
-            f"  bid1={q.bid_price[0]:10.3f}"
-            f"  ask1={q.ask_price[0]:10.3f}"
-            f"  vol={q.bid_volume[0]}"
-        )
-
-    def on_heartbeat(self):
-        pass
+        print(f"[{self.count:5d}] src={q.source:<9s} {q.exchange_id}.{q.instrument_id}"
+              f"  last={q.last_price:9.3f}  bid1={q.bid_price[0]:9.3f}"
+              f"  ask1={q.ask_price[0]:9.3f}  vol={q.volume}")
 
 
 def main():
@@ -81,35 +64,23 @@ def main():
     port = int(sys.argv[2]) if len(sys.argv) > 2 else 9001
     source = sys.argv[3] if len(sys.argv) > 3 else ""
 
-    spi = MyQuoteSpi()
+    spi = DemoSpi()
     api = QuoteApi()
     api.register_spi(spi)
-
     if api.connect(host, port) != 0:
-        print("[Client] connect failed")
+        print("[client] connect failed")
         return 1
 
-    #time.sleep(0.2)
-    #api.login("trader1", "pass1234")
-    #time.sleep(0.3)
-
     if source:
-        print(f"[Client] subscribing source={source} 600519.SSE")
+        print(f"[client] subscribe {source}:SSE.600519")
         api.subscribe(["600519"], "SSE", source=source)
     else:
-        # 一条连接混订两源同一合约，回调里靠 quote.source 区分
-        print("[Client] multiplexing webquote + sim on 600519.SSE")
+        print("[client] multiplex webquote + sim on SSE.600519（回调按 quote.source 区分）")
         api.subscribe(["600519"], "SSE", source="webquote")
         api.subscribe(["600519"], "SSE", source="sim")
 
-    time.sleep(5)
-    if not g_stop.is_set() and source:
-        print("\n[Client] unsubscribing 600519...")
-        api.unsubscribe(["600519"], "SSE", source=source)
-
-    g_stop.wait()  # blocks until set by signal or disconnect
-
-    print(f"\n[Client] total quotes: {spi.count}")
+    stop.wait()          # Ctrl+C 或断线后退出
+    print(f"\n[client] total quotes: {spi.count}")
     api.disconnect()
     return 0
 

--- a/libfinance/subscribe/md_protocol.py
+++ b/libfinance/subscribe/md_protocol.py
@@ -22,6 +22,8 @@ class MsgType(IntEnum):
     RSP_SUBSCRIBE   = 0x0004
     REQ_UNSUBSCRIBE = 0x0005
     RSP_UNSUBSCRIBE = 0x0006
+    REQ_SUBSCRIBE_ALL = 0x0007   # 全市场订阅（按 source）；body 复用 SubReq，仅 source 有效
+    RSP_SUBSCRIBE_ALL = 0x0008
     MD_QUOTE        = 0x0010
     HEARTBEAT       = 0x00FF
 

--- a/libfinance/subscribe/quote_api.py
+++ b/libfinance/subscribe/quote_api.py
@@ -100,6 +100,15 @@ class QuoteApi:
             last = seq
         return last
 
+    # ── 全市场订阅（按 source）────────────────────────────────────
+    # 一条请求让网关触发该源 subscribe_all（webquote→yunhq 全量 list，覆盖全沪深 ~5000+ 只），
+    # 之后本连接收到该源所有 instrument 的行情，无需逐只订阅。须已登录。
+    def subscribe_all(self, source: str = "") -> int:
+        seq = self._next_seq()
+        body = pack_sub_req("", "", source)
+        self._enqueue(make_frame(MsgType.REQ_SUBSCRIBE_ALL, seq, body))
+        return seq
+
     # ── 退订 ──────────────────────────────────────────────────────
     def unsubscribe(self, instruments: List[str], exchange_id: str, source: str = "") -> int:
         last = 0
@@ -212,7 +221,7 @@ class QuoteApi:
         t = MsgType(msg_type)
         if t == MsgType.RSP_LOGIN:
             self._spi.on_rsp_login(unpack_login_rsp(body), seq_no)
-        elif t == MsgType.RSP_SUBSCRIBE:
+        elif t == MsgType.RSP_SUBSCRIBE or t == MsgType.RSP_SUBSCRIBE_ALL:
             self._spi.on_rsp_subscribe(unpack_sub_rsp(body), seq_no)
         elif t == MsgType.RSP_UNSUBSCRIBE:
             self._spi.on_rsp_unsubscribe(unpack_sub_rsp(body), seq_no)


### PR DESCRIPTION
新增 `QuoteApi.subscribe_all(source)`：一条请求让网关触发该源 subscribe_all（webquote→yunhq 全沪深 ~5289 只全覆盖），之后本连接收到该源所有 instrument 行情，无需逐只订阅。

- `md_protocol.py`：加 `REQ/RSP_SUBSCRIBE_ALL`（0x0007/0x0008）
- `quote_api.py`：加 `subscribe_all(source)` + dispatch RSP_SUBSCRIBE_ALL

配合 mdgateway 的 subscribe_all 链路（walkacross/mdgateway#17）。盘中实测：`subscribe_all("webquote")` 一条 → 收到 5289 只不同合约（SSE 2356 + SZE 2933）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)