### PR TITLE
feat(concept): forward date param in get_concept_weights

### DIFF
--- a/libfinance/api/concept_components.py
+++ b/libfinance/api/concept_components.py
@@ -81,4 +81,4 @@ def get_concept_weights(concept_ids:list, date=None, source:str="THS") -> pd.Dat
         
         [25 rows x 7 columns]
     """
-    return get_client().get_concept_weights(concept_ids=concept_ids, source = source)
+    return get_client().get_concept_weights(concept_ids=concept_ids, date=date, source=source)


### PR DESCRIPTION
客户端 `get_concept_weights` 已声明 `date` 却未透传; 现接到 RPC → 服务端 point-in-time 取概念在 date 当期(<= date 最近一期)的成分, 与 `get_index_weights` 语义一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)